### PR TITLE
RDM-12805 - FT_GlobalSearch case type for testing GlobalSearch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 apply plugin: 'java'
 
-def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "7.5.2_RDM_12805_GLOBAL_SEARCH_V2"
+def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "7.5.2"
 
 group 'com.github.hmcts'
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDM-12805

### Change description ###

Add FT_GlobalSearch case type required for GlobalSearch FTA tests

This depends on SearchCriteria base type being present in the def store DB and so cannot be released until the def store `global_search` branch has been merged back in

**Does this PR introduce a breaking change?** (check one with "x")

```
[X] Yes
[ ] No
```
